### PR TITLE
Permanet whitelisted players (exclusion)

### DIFF
--- a/NamelessSpigot/resources/config.yml
+++ b/NamelessSpigot/resources/config.yml
@@ -56,6 +56,9 @@ auto-whitelist-registered:
   poll-interval: 300
   # Send log messages when whitelisting or unwhitelisting users
   log: true
+  # Keep the following players permanently whitelisted despite not having a registered or activated account
+  permanent-whitelisted:
+  - playername
   
 # Configure the user agent to be more like something a browser would send if requests
 # from the plugins are being blocked.

--- a/NamelessSpigot/src/com/namelessmc/plugin/spigot/WhitelistRegistered.java
+++ b/NamelessSpigot/src/com/namelessmc/plugin/spigot/WhitelistRegistered.java
@@ -25,7 +25,9 @@ public class WhitelistRegistered implements Runnable {
 		final boolean hideInactive = Config.MAIN.getConfig().getBoolean("auto-whitelist-registered.exclude-inactive");
 		final boolean hideBanned = Config.MAIN.getConfig().getBoolean("auto-whitelist-registered.exclude-banned");
 		final boolean log = Config.MAIN.getConfig().getBoolean("auto-whitelist-registered.log");
-
+		
+		List<String> permWhitelistUUID = new List<>();
+		
 		final Logger logger = NamelessPlugin.getInstance().getLogger();
 
 		Bukkit.getScheduler().runTaskAsynchronously(NamelessPlugin.getInstance(), () -> {
@@ -38,15 +40,21 @@ public class WhitelistRegistered implements Runnable {
 				e.printStackTrace();
 				return;
 			}
+			
+			Config.MAIN.getConfig().getStringList("permanent-whitelisted")
+			.forEach(playername -> permWhitelistUUID.add(playername.getUniqueId()));		
 
 			Bukkit.getScheduler().runTask(NamelessPlugin.getInstance(), () -> {
 				for (final OfflinePlayer whitelistedPlayer : Bukkit.getWhitelistedPlayers()) {
 					if (!uuids.contains(whitelistedPlayer.getUniqueId())) {
-						// The player is whitelisted, but no(t) (longer) registered.
-						whitelistedPlayer.setWhitelisted(false);
-						uuids.remove(whitelistedPlayer.getUniqueId());
-						if (log) {
-							logger.info("Removed " + whitelistedPlayer.getName() + " from the whitelist.");
+						// The player is not on the permanent whitelist exclusion list
+						if (!permanentWhitelisted.contains(whitelistedPlayer.getUniqueId())) {						
+							// The player is whitelisted, but no(t) (longer) registered.
+							whitelistedPlayer.setWhitelisted(false);
+							uuids.remove(whitelistedPlayer.getUniqueId());
+							if (log) {
+								logger.info("Removed " + whitelistedPlayer.getName() + " from the whitelist.");
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Added a functionality to the "automatic whitelist registered users" logic that also accepts a list of configured users to stay whitelisted although they're not registered in the forums.

NOT TESTED as I have no knowledge of how to compile plugins.